### PR TITLE
feat: support mutating docker image versions

### DIFF
--- a/nuxeo/templates/deployment.yaml
+++ b/nuxeo/templates/deployment.yaml
@@ -32,8 +32,13 @@ spec:
 {{- with .Values.podLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}
-{{- if .Values.podAnnotations }}
       annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        rollme: {{ ternary (randAlphaNum 5 | quote) .Values.image.tag (or (eq "latest" (lower .Values.image.tag)) (hasSuffix "snapshot" (lower .Values.image.tag))) }}
+        {{- if .Values.podAnnotations }}
+        {{ toYaml .Values.podAnnotations | indent 8 }}
+    {{- end }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
@@ -52,7 +57,7 @@ spec:
             cpu: "{{ .Values.resources.limits.cpu }}"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
 {{- if .Values.image.pullPolicy }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        imagePullPolicy: {{ ternary ("Always") (.Values.image.pullPolicy) (or (eq "latest" (lower .Values.image.tag)) (hasSuffix "snapshot" (lower .Values.image.tag))) }}
 {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}


### PR DESCRIPTION
- roll the deployment when image version is latest or ends with snapshot
- roll the deployment when config/secrets changed
- Pull the image always when the image version is mutable image version